### PR TITLE
[TD-2078] Order in Concepts and Ingests table is not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.6.0]
+
+### Fixed
+
+- [TD-2078] keep the order of incoming resources when rendering hypermedia list
+
 ## [3.2.0] 2019-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [3.6.0]
 
-### Fixed
+### Changed
 
-- [TD-2078] keep the order of incoming resources when rendering hypermedia list
+- [TD-2078] Preserve collection order in ControllerHelper.collection_hypermedia/2
 
 ## [3.2.0] 2019-07-22
 

--- a/lib/td_hypermedia/controller_helper.ex
+++ b/lib/td_hypermedia/controller_helper.ex
@@ -10,11 +10,7 @@ defmodule TdHypermedia.ControllerHelper do
   def collection_hypermedia(helper, conn, resource, resource_type) do
     %Collection{
       collection_hypermedia: hypermedia(helper, conn, %{}, resource_type),
-      collection:
-        Enum.into(
-          Enum.map(resource, &{&1, hypermedia(helper, conn, &1, [])}),
-          %{}
-        )
+      collection: Enum.map(resource, &{&1, hypermedia(helper, conn, &1, [])})
     }
   end
 

--- a/lib/td_hypermedia/view_helper.ex
+++ b/lib/td_hypermedia/view_helper.ex
@@ -27,15 +27,10 @@ defmodule TdHypermedia.ViewHelper do
     )
   end
 
-  defp render_many_hypermedia_element(resources, collection, view, template, assigns) do
-    resources
-    |> Enum.map(&(merge_actions(&1, collection)))
+  defp render_many_hypermedia_element(_resources, collection, view, template, assigns) do
+    collection
+    |> Enum.map(fn {resource, actions} -> Map.merge(render_hypermedia(actions), resource) end)
     |> Enum.map(fn resource -> render_one(resource, view, template, assigns) end)
-  end
-
-  defp merge_actions(resource, collection) do
-    actions = Map.get(collection, resource)
-    Map.merge(render_hypermedia(actions), resource)
   end
 
   defp render_hypermedia(hypermedia) do

--- a/lib/td_hypermedia/view_helper.ex
+++ b/lib/td_hypermedia/view_helper.ex
@@ -27,10 +27,15 @@ defmodule TdHypermedia.ViewHelper do
     )
   end
 
-  defp render_many_hypermedia_element(_resources, collection, view, template, assigns) do
-    collection
-    |> Enum.map(fn {resource, actions} -> Map.merge(render_hypermedia(actions), resource) end)
+  defp render_many_hypermedia_element(resources, collection, view, template, assigns) do
+    resources
+    |> Enum.map(&(merge_actions(&1, collection)))
     |> Enum.map(fn resource -> render_one(resource, view, template, assigns) end)
+  end
+
+  defp merge_actions(resource, collection) do
+    actions = Map.get(collection, resource)
+    Map.merge(render_hypermedia(actions), resource)
   end
 
   defp render_hypermedia(hypermedia) do

--- a/lib/td_hypermedia/view_helper.ex
+++ b/lib/td_hypermedia/view_helper.ex
@@ -20,22 +20,6 @@ defmodule TdHypermedia.ViewHelper do
     )
   end
 
-  def render_many_hypermedia_resources(resources, hypermedia, view, template, assigns \\ %{}) do
-    Map.merge(
-      render_hypermedia(hypermedia.collection_hypermedia),
-      %{
-        "data" =>
-          render_many_hypermedia_resource(
-            resources,
-            hypermedia.collection,
-            view,
-            template,
-            assigns
-          )
-      }
-    )
-  end
-
   def render_one_hypermedia(resource, hypermedia, view, template, assigns \\ %{}) do
     Map.merge(
       render_hypermedia(hypermedia),
@@ -43,13 +27,7 @@ defmodule TdHypermedia.ViewHelper do
     )
   end
 
-  defp render_many_hypermedia_element(_resources, collection, view, template, assigns) do
-    collection
-    |> Enum.map(fn {resource, actions} -> Map.merge(render_hypermedia(actions), resource) end)
-    |> Enum.map(fn resource -> render_one(resource, view, template, assigns) end)
-  end
-
-  defp render_many_hypermedia_resource(resources, collection, view, template, assigns) do
+  defp render_many_hypermedia_element(resources, collection, view, template, assigns) do
     resources
     |> Enum.map(&(merge_actions(&1, collection)))
     |> Enum.map(fn resource -> render_one(resource, view, template, assigns) end)

--- a/lib/td_hypermedia/view_helper.ex
+++ b/lib/td_hypermedia/view_helper.ex
@@ -20,6 +20,22 @@ defmodule TdHypermedia.ViewHelper do
     )
   end
 
+  def render_many_hypermedia_resources(resources, hypermedia, view, template, assigns \\ %{}) do
+    Map.merge(
+      render_hypermedia(hypermedia.collection_hypermedia),
+      %{
+        "data" =>
+          render_many_hypermedia_resource(
+            resources,
+            hypermedia.collection,
+            view,
+            template,
+            assigns
+          )
+      }
+    )
+  end
+
   def render_one_hypermedia(resource, hypermedia, view, template, assigns \\ %{}) do
     Map.merge(
       render_hypermedia(hypermedia),
@@ -27,7 +43,13 @@ defmodule TdHypermedia.ViewHelper do
     )
   end
 
-  defp render_many_hypermedia_element(resources, collection, view, template, assigns) do
+  defp render_many_hypermedia_element(_resources, collection, view, template, assigns) do
+    collection
+    |> Enum.map(fn {resource, actions} -> Map.merge(render_hypermedia(actions), resource) end)
+    |> Enum.map(fn resource -> render_one(resource, view, template, assigns) end)
+  end
+
+  defp render_many_hypermedia_resource(resources, collection, view, template, assigns) do
     resources
     |> Enum.map(&(merge_actions(&1, collection)))
     |> Enum.map(fn resource -> render_one(resource, view, template, assigns) end)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TdHypermedia.MixProject do
   def project do
     [
       app: :td_hypermedia,
-      version: "3.2.0",
+      version: "3.6.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
keep the order of incoming resources when rendering hypermedia list